### PR TITLE
Update to use TriggerContextData and disable deno lock

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,5 +1,6 @@
 {
   "importMap": "import_map.json",
+  "lock": false,
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test --allow-read --allow-none"
   }

--- a/triggers/greeting_trigger.ts
+++ b/triggers/greeting_trigger.ts
@@ -1,5 +1,5 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData } from "deno-slack-api/mod.ts";
+import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
 import GreetingWorkflow from "../workflows/greeting_workflow.ts";
 
 /**
@@ -9,7 +9,7 @@ import GreetingWorkflow from "../workflows/greeting_workflow.ts";
  * https://api.slack.com/automation/triggers
  */
 const greetingTrigger: Trigger<typeof GreetingWorkflow.definition> = {
-  type: "shortcut",
+  type: TriggerTypes.Shortcut,
   name: "Send a greeting",
   description: "Send greeting to channel",
   workflow: "#/workflows/greeting_workflow",

--- a/triggers/greeting_trigger.ts
+++ b/triggers/greeting_trigger.ts
@@ -1,4 +1,5 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
+import { TriggerContextData } from "deno-slack-api/mod.ts";
 import GreetingWorkflow from "../workflows/greeting_workflow.ts";
 
 /**
@@ -14,10 +15,10 @@ const greetingTrigger: Trigger<typeof GreetingWorkflow.definition> = {
   workflow: "#/workflows/greeting_workflow",
   inputs: {
     interactivity: {
-      value: "{{data.interactivity}}",
+      value: TriggerContextData.Shortcut.interactivity,
     },
     channel: {
-      value: "{{data.channel_id}}",
+      value: TriggerContextData.Shortcut.channel_id,
     },
   },
 };


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

Use the `TriggerTypes` object, the `TriggerContextData` object instead of using the templatized strings like `{{data.interactivity}}`, and disable `deno.lock` based on recent convos

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
